### PR TITLE
Fix README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed macro generation so encrust could actually be used by other crates without depending on both
   `encrust` and `encrust_core`.
 * Upgraded Rust edition to 2024 and set the minimum supported rust version to 1.85.
-* Removed `new_with_random` from `Encrusted` as generating new random values are easier now that
-  only a single u64 is needed.
-* Modified the `reseed` function to accept an new seed instead of an RNG to generate a new seed.
+* Removed `rand` feature flag
+  * Removed `new_with_random` from `Encrusted` as generating new random values are easier now that
+    only a single u64 is needed.
+  * Modified the `reseed` function to accept an new seed instead of an RNG to generate a new seed.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Encrust has the following feature flags, all enabled by default:
 * `std`: Compile with std. Removing this causes the crate to be built as no_std.
 * `macros`: Include macros used for Derive macro and proc macros for obfuscating values at
   compile-time.
-* `rand`: Includes functions to obfuscate data at run-time using a `rand::Rng`, as well as a
-  function to change the seed used.
 
 ## License
 


### PR DESCRIPTION
The rand flag was removed in version 0.2.0. This change reflects that in the readme and changelog.