### PR TITLE
Add lifetime to `Encrusted<T>::decrust` signature

### DIFF
--- a/crates/encrust-core/src/lib.rs
+++ b/crates/encrust-core/src/lib.rs
@@ -93,7 +93,7 @@ where
 
     /// Deobfuscates the data contained in [`Encrusted`] and returns a [`Decrusted`] object that can
     /// be used to access and modify the actual data.
-    pub fn decrust(&mut self) -> Decrusted<T> {
+    pub fn decrust(&mut self) -> Decrusted<'_, T> {
         Decrusted::new(self)
     }
 }


### PR DESCRIPTION
The `mismatched-lifetime-syntaxes` lint was added to Rust nightly 1.89.0. This PR fixes the new lint error by adding an anonymous lifetime to `decrust`'s result type.