### PR TITLE
Set static seed for most tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Set a fixed seed for tests to make the tests deterministic. There are still some randomness in the
+  tests, but this *should* not cause test failures in most cases.
+
 # Version 0.2.1 - 2025-06-18
 
 * Fixed encrust on big endian architectures. [#11]

--- a/crates/encrust-core/src/lib.rs
+++ b/crates/encrust-core/src/lib.rs
@@ -274,7 +274,7 @@ mod tests {
     const TEST_STRING: &str = "The quick brown fox jumps over the lazy dog😊";
 
     fn get_seed() -> u64 {
-        rand::rng().next_u64()
+        0x2357_bd11_1317_1d1f
     }
 
     macro_rules! test_ints {

--- a/crates/encrust-macros/tests/derive_encrust.rs
+++ b/crates/encrust-macros/tests/derive_encrust.rs
@@ -2,7 +2,7 @@
 
 use encrust_core::Encrustable;
 use encrust_macros::*;
-use rand::{RngCore, SeedableRng, rngs::SmallRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use zeroize::Zeroize;
 
 const TEST_STRING: &str = "The quick brown fox jumps over the lazy dog😊";
@@ -40,7 +40,7 @@ enum NamedOrTuple {
 struct Generic<T, U: PartialEq, P: Encrustable>(T, U, P);
 
 fn gen_seed() -> u64 {
-    rand::rng().next_u64()
+    0x2357_bd11_1317_1d1f
 }
 
 #[test]


### PR DESCRIPTION
This should reduce the number of test fails. There are still some use of random numbers in the tests, but these are less likely to fail due to the low chance of collisions in most cases. The tests that have failed most so far have been tests that a single byte is not equal to itself after encrusting, which can happen quite often.