### PR TITLE
Upgrade rapidhash dependency to v4.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Set a fixed seed for tests to make the tests deterministic. There are still some randomness in the
   tests, but this *should* not cause test failures in most cases.
+* Upgraded `rapidhash` dependency to v4.1.0.
 
 # Version 0.2.1 - 2025-06-18
 

--- a/crates/encrust-core/Cargo.toml
+++ b/crates/encrust-core/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 [dependencies]
 rand = { "version" = "0.9.0", default-features = false, features = ["small_rng", "alloc"] }
 zeroize = { version = "1.6.0", features = ["derive"] }
-rapidhash = { version = "1.3.0", default-features = false, optional = true }
+rapidhash = { version = "4.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { "version" = "0.9.0", default-features = false, features = ["thread_rng"] }


### PR DESCRIPTION
Users of this crate should not notice any major changes. `Hashstring` and `Hashbytes` may have somewhat increased performance, although this crate does not have a benchmark suite to back up that claim.