### PR TITLE
Fix generated documentation take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# Version 0.3.1 and 0.3.2 - 2025-11-27
+* Remove configuration and annotations that are no longer needed to generate documentation.
+  Information about required feature flags are now added automatically.
+* Added `#[cfg(feature = "hashstrings")]` to types in the `hashstrings` module of `encrust-core`.
+  This was done to include information about the required `hashstrings` feature to use types defined
+  in the `hashstrings` module.
+
 # Version 0.3.0 - 2025-10-15
 
 * Set a fixed seed for tests to make the tests deterministic. There are still some randomness in the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["obfuscation"]
 license = "MIT"
 repository = "https://github.com/emiltayl/encrust/"
 rust-version = "1.85"
-version = "0.3.1"
+version = "0.3.2"
 
 [workspace.lints.rust]
 deprecated_safe = { level = "deny", priority = 1 } 

--- a/crates/encrust-core/Cargo.toml
+++ b/crates/encrust-core/Cargo.toml
@@ -27,8 +27,6 @@ std = ["rand/std", "rapidhash?/std", "zeroize/std"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
-cargo-args = ["--no-deps"]
 
 [lints]
 workspace = true

--- a/crates/encrust-core/src/hashstrings.rs
+++ b/crates/encrust-core/src/hashstrings.rs
@@ -3,11 +3,15 @@
 //! Macros are used to make it possible to ensure that the plain text is not present in the
 //! executable, see the documentation for [`encrust`] for examples of macro usage.
 
+// Note that items in this crate are behind `#[cfg(feature = "hashstrings")]` to ensure that the
+// generated documentation can display that the types require having the "hashstrings" feature
+// enabled.
+
 use rapidhash::v3::{RapidSecrets, rapidhash_v3_seeded};
 use zeroize::Zeroize;
 
 /// Used to specify whether a [`Hashstring`] should ignore case when comparing strings.
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
+#[cfg(feature = "hashstrings")]
 pub enum Sensitivity {
     /// Ignore case when comparing strings.
     CaseInsensitive,
@@ -31,13 +35,14 @@ pub enum Sensitivity {
 /// assert!(case_insensitive_hashstring == "A string");
 /// assert!(case_insensitive_hashstring == "a string");
 /// ```
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
+#[cfg(feature = "hashstrings")]
 pub struct Hashstring {
     value: u64,
     seed: u64,
     sensitivity: Sensitivity,
 }
 
+#[cfg(feature = "hashstrings")]
 impl Hashstring {
     /// Create a new [`Hashstring`] using the provided string and random seed.
     ///
@@ -70,7 +75,6 @@ impl Hashstring {
     /// Used by the macros to get the hash value to create `Hashstring` from raw data.
     /// Should not be used outside of the provided macros.
     #[doc(hidden)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
     #[cfg(feature = "macros")]
     pub fn get_raw_value(&self) -> u64 {
         self.value
@@ -79,7 +83,6 @@ impl Hashstring {
     /// Used by the macros to create `Hashstring` from raw data.
     /// Should not be used outside of the provided macros.
     #[doc(hidden)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
     #[cfg(feature = "macros")]
     pub fn new_from_raw_value(value: u64, seed: u64, sensitivity: Sensitivity) -> Self {
         Self {
@@ -90,6 +93,7 @@ impl Hashstring {
     }
 }
 
+#[cfg(feature = "hashstrings")]
 impl PartialEq<&str> for Hashstring {
     fn eq(&self, other: &&str) -> bool {
         let seed = RapidSecrets::seed_cpp(self.seed);
@@ -115,12 +119,13 @@ impl PartialEq<&str> for Hashstring {
 /// assert!(hashbytes == &[1, 2, 3]);
 /// assert!(hashbytes != &[4, 5, 6]);
 /// ```
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
+#[cfg(feature = "hashstrings")]
 pub struct Hashbytes {
     value: u64,
     seed: u64,
 }
 
+#[cfg(feature = "hashstrings")]
 impl Hashbytes {
     /// Create a new [`Hashbytes`] using the provided `u8` slice and random seed.
     ///
@@ -136,7 +141,6 @@ impl Hashbytes {
     /// Used by the macros to get the hash value to create `Hashbytes` from raw data.
     /// Should not be used outside of the provided macros.
     #[doc(hidden)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
     #[cfg(feature = "macros")]
     pub fn get_raw_value(&self) -> u64 {
         self.value
@@ -145,13 +149,13 @@ impl Hashbytes {
     /// Used by the macros to create `Hashbytes` from raw data.
     /// Should not be used outside of the provided macros.
     #[doc(hidden)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
     #[cfg(feature = "macros")]
     pub fn new_from_raw_value(value: u64, seed: u64) -> Self {
         Self { value, seed }
     }
 }
 
+#[cfg(feature = "hashstrings")]
 impl PartialEq<&[u8]> for Hashbytes {
     fn eq(&self, other: &&[u8]) -> bool {
         let rapid_secrets = RapidSecrets::seed_cpp(self.seed);

--- a/crates/encrust-core/src/lib.rs
+++ b/crates/encrust-core/src/lib.rs
@@ -62,7 +62,6 @@ where
     /// Using this may cause data to be scrambled in unpredictable ways that could lead to safety
     /// issues. This should not be used manually, but only through the provided macros.
     #[doc(hidden)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
     #[cfg(feature = "macros")]
     pub const unsafe fn from_encrusted_data(data: T, seed: u64) -> Self {
         Self { data, seed }

--- a/crates/encrust-macros/Cargo.toml
+++ b/crates/encrust-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 zeroize = "1.6.0"
 
 [dependencies]
-encrust-core = { path = "../encrust-core", version = "0.3.1" }
+encrust-core = { path = "../encrust-core", version = "0.3.2" }
 proc-macro2 = "1.0.67"
 quote = "1.0.33"
 rand = "0.9.0"
@@ -30,8 +30,6 @@ std = []
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
-cargo-args = ["--no-deps"]
 
 [lints]
 workspace = true

--- a/crates/encrust-macros/src/lib.rs
+++ b/crates/encrust-macros/src/lib.rs
@@ -31,7 +31,6 @@ use crate::{
 /// assert_eq!(&[1i32, 2i32, 3i32], array.decrust().as_slice());
 /// ```
 #[proc_macro]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub fn encrust(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as Literal).generate_output_tokens()
 }
@@ -50,7 +49,6 @@ pub fn encrust(input: TokenStream) -> TokenStream {
 /// );
 /// ```
 #[proc_macro]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub fn encrust_vec(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as LiteralVec).generate_output_tokens()
 }
@@ -70,7 +68,6 @@ pub fn encrust_vec(input: TokenStream) -> TokenStream {
 /// let mut cargo_toml = encrust_file_string!("Cargo.toml");
 /// ```
 #[proc_macro]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub fn encrust_file_string(input: TokenStream) -> TokenStream {
     StringFileReader::from(parse_macro_input!(input as FilePath)).generate_output_tokens()
 }
@@ -90,7 +87,6 @@ pub fn encrust_file_string(input: TokenStream) -> TokenStream {
 /// let mut cargo_toml = encrust_file_bytes!("Cargo.toml");
 /// ```
 #[proc_macro]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub fn encrust_file_bytes(input: TokenStream) -> TokenStream {
     BytesFileReader::from(parse_macro_input!(input as FilePath)).generate_output_tokens()
 }
@@ -108,8 +104,6 @@ pub fn encrust_file_bytes(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[cfg(feature = "hashstrings")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
 pub fn hashstring(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as ToHashString).generate_output_tokens_case_sensitive()
 }
@@ -126,8 +120,6 @@ pub fn hashstring(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[cfg(feature = "hashstrings")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
 pub fn hashstring_ci(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as ToHashString).generate_output_tokens_case_insensitive()
 }
@@ -144,8 +136,6 @@ pub fn hashstring_ci(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[cfg(feature = "hashstrings")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "hashstrings")))]
 pub fn hashbytes(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as ToHashBytes).generate_output_tokens()
 }
@@ -154,7 +144,6 @@ pub fn hashbytes(input: TokenStream) -> TokenStream {
 ///
 /// This requires that all fields are `Encrustable`. Currently, no other options are available.
 #[proc_macro_derive(Encrustable)]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub fn derive_encrustable_macro(input: TokenStream) -> TokenStream {
     derive::derive_encrustable(parse_macro_input!(input as syn::DeriveInput))
 }

--- a/crates/encrust/Cargo.toml
+++ b/crates/encrust/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-encrust-core = { path = "../encrust-core", "version" = "0.3.1", default-features = false }
-encrust-macros = { path = "../encrust-macros", "version" = "0.3.1", default-features = false, optional = true }
+encrust-core = { path = "../encrust-core", "version" = "0.3.2", default-features = false }
+encrust-macros = { path = "../encrust-macros", "version" = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.9.0"
@@ -27,8 +27,6 @@ std = ["encrust-core/std", "encrust-macros?/std"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
-cargo-args = ["--no-deps"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
This commit removes annotations and configuration that are no longer needed. Every types in the `hashstrings` module require a `#[cfg(feature = "hashstrings")` annotation to make sure the documentation is generated properly even though the module they are defined in already is gated behind that feature flag. This seems to be a limitation of rustdoc.